### PR TITLE
A few more tweaks, in case the are of interest!

### DIFF
--- a/pipenv_pex/pipenv_pex.py
+++ b/pipenv_pex/pipenv_pex.py
@@ -109,7 +109,7 @@ def main(exclude: List[str], pex_args: tuple):
     info("Dependencies found:{}\n- {}".format(Fore.WHITE, "\n- ".join(deps)))
 
     irrelevant = FILES_IRRELEVANT_TO_PEX + list(exclude)
-    info("Stashing away excluded files...")
+    info("Copying files to temp project directory...")
 
     outpath = Path(output)
     if outpath.exists():
@@ -119,7 +119,7 @@ def main(exclude: List[str], pex_args: tuple):
     with TempProjDir(proj_dir, irrelevant) as d:
         info("Running pex...")
         pex_main([*deps, "--sources-directory", d, *pex_args])
-        info("Cleaning up temp files...")
+        info("Cleaning up temp project directory...")
 
     print(Fore.GREEN + "Done!")
 

--- a/pipenv_pex/pipenv_pex.py
+++ b/pipenv_pex/pipenv_pex.py
@@ -119,7 +119,7 @@ def main(exclude: List[str], pex_args: tuple):
     with TempProjDir(proj_dir, irrelevant) as d:
         info("Running pex...")
         pex_main([*deps, "--sources-directory", d, *pex_args])
-        info("Popping back stashed files...")
+        info("Cleaning up temp files...")
 
     print(Fore.GREEN + "Done!")
 

--- a/pipenv_pex/pipenv_pex.py
+++ b/pipenv_pex/pipenv_pex.py
@@ -1,3 +1,4 @@
+import shutil
 import tempfile
 from pathlib import Path
 from sys import stderr
@@ -9,7 +10,12 @@ from pex.bin.pex import main as pex_main  # type: ignore
 from pipenv.project import Project  # type: ignore
 
 FILES_IRRELEVANT_TO_PEX = [
-    "Pipfile", "Pipfile.lock", ".mypy_cache", "__pycache__"
+    "Pipfile",
+    "Pipfile.lock",
+    ".mypy_cache",
+    "__pycache__",
+    ".git*",
+    ".idea"
 ]
 
 
@@ -25,22 +31,10 @@ def error(object):
     print(f"{Fore.RED}{object}{Style.RESET_ALL}", file=stderr)
 
 
-class StashAwayFiles:
+class TempProjDir:
     """
-    Context manager for temporarily moving away certain file in a directory.
-    On exit, the files are moved back to their original home <3
-
-        >>> from pathlib import Path; import os
-        >>> Path("test").mkdir(exist_ok=True)
-        >>> Path("test/in").touch()
-        >>> Path("test/bad").touch()
-        >>> with StashAwayFiles(origin="test", ["bad"]):
-                os.listdir()
-        ...
-        ['test/in']
-        >>> os.listdir()
-        ['test/in', 'test/bad']
-
+    Context manager the creates a temp dir and copies current contents,
+    minus excluded patterns
     """
 
     def __init__(self, origin, patterns: List[str]):
@@ -48,19 +42,13 @@ class StashAwayFiles:
         self.origin = Path(origin)
 
     def __enter__(self):
-        # using home dir instead of /tmp becuase it's impossible to truly move
-        # files between different filesystems - moving a file pointer around is
-        # only possible within the same filesystem. since all we want is to
-        # hide these files for a moment, meaning moving a pointer, we'll have
-        # to pick a directory within the same filesystem we're currently on.
-        self.tmpdir = tempfile.TemporaryDirectory(dir=str(Path.home()))
-        for pattern in self.patterns:
-            for f in self.origin.glob(pattern):
-                f.rename(f"{self.tmpdir.name}/{f.name}")
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.dest = Path(self.tmpdir.name) / 'tmp_proj'
+        shutil.copytree(self.origin, self.dest, ignore=shutil.ignore_patterns(*self.patterns))
+        return self.dest
 
     def __exit__(self, type, value, traceback):
-        for f in Path(self.tmpdir.name).iterdir():
-            f.rename(f"{self.origin}/{f.name}")
+        self.tmpdir.cleanup()
 
 
 def contains_any(container: Container, items: Iterable) -> bool:
@@ -76,9 +64,10 @@ def contains_any(container: Container, items: Iterable) -> bool:
           "--exclude",
           multiple=True,
           help="Don't include these files/directories in the resulting .pex "
-          "file. In addition to files/dirs added using this option, these are "
-          "excluded by deafult:\n{}.".format(
+               "file. In addition to files/dirs added using this option, these are "
+               "excluded by default:\n{}.".format(
               ", ".join(FILES_IRRELEVANT_TO_PEX)))
+@c.version_option()
 @c.argument("pex_args", nargs=-1, type=c.UNPROCESSED)
 def main(exclude: List[str], pex_args: tuple):
     project = Project()
@@ -97,7 +86,7 @@ def main(exclude: List[str], pex_args: tuple):
         try:
             for flag in output_flags:
                 try:
-                    output = pex_args[pex_args.index(flag)+1]
+                    output = pex_args[pex_args.index(flag) + 1]
                     break  # just return first hit
                 except ValueError:
                     # flag not present
@@ -127,9 +116,9 @@ def main(exclude: List[str], pex_args: tuple):
         warning(f"{outpath.name} already exists, deleting it...")
         outpath.unlink()
 
-    with StashAwayFiles(proj_dir, irrelevant):
+    with TempProjDir(proj_dir, irrelevant) as d:
         info("Running pex...")
-        pex_main([*deps, "--sources-directory", proj_dir, *pex_args])
+        pex_main([*deps, "--sources-directory", d, *pex_args])
         info("Popping back stashed files...")
 
     print(Fore.GREEN + "Done!")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pipenv-pex",
-    version="0.2.2",
+    version="0.2.3",
     author="Maor Kadosh",
     description="Generate Python executable files via PEX using info from Pipfile",
     long_description=long_description,


### PR DESCRIPTION
- Changed 'stash away files' logic to 'copy everything _but_ excludes to temp dir' for two reasons:
   - When playing with pipenv-pex, script crashed (before -o fix) and a bunch of project directory files where gone! Actually, they were stashed because script crashed before restoring them, but it was confusing--with new logic, worst case in crash is that the tmp directory is not deleted. Project dir is always undisturbed
   - Get to use shutil.copytree's 'ignore' option to handle exclude glob patterns
- Added '--version' option (via click.version_option)
- Minor formatting changes (via PyCharm beautify)
- bumped minor revision in setup.py